### PR TITLE
Fix docs tutorials in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,33 +3,35 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2023-04-28
 
-- Update - Attribute names relative to issues #20, #22, #26
-- Add - Tutorial pages
-- Add - Quality Control plotting tool and report schema
++ Update - Attribute names relative to issues #20, #22, #26
++ Add - Tutorial pages
++ Add - Quality Control plotting tool and report schema
++ Fix - `.ipynb` output in tutorials is not visible in dark mode.
+
 
 ## [0.1.4] - 2022-10-21
 
-- Add - mkdocs deployment with workflow API docs
-- Update - processing_method: char(16) -> varchar(16)
++ Add - mkdocs deployment with workflow API docs
++ Update - processing_method: char(16) -> varchar(16)
 
 ## [0.1.3] - 2022-10-11
 
-- Update - CICD workflows for PyPI release
++ Update - CICD workflows for PyPI release
 
 ## [0.1.2] - 2022-05-10
 
-- Add - Load data acquired with Miniscope-DAQ-V4
-- Add - Load data analyzed with CaImAn
-- Add - Trigger CaImAn analysis
-- Remove - Load data analyzed with MiniscopeAnalysis
-- Add - Adopted black formatting into code base
++ Add - Load data acquired with Miniscope-DAQ-V4
++ Add - Load data analyzed with CaImAn
++ Add - Trigger CaImAn analysis
++ Remove - Load data analyzed with MiniscopeAnalysis
++ Add - Adopted black formatting into code base
 
 ## [0.1.1] - 2021-04-01
 
-- Add - Load data acquired with Miniscope-DAQ-V3
-- Add - Load data analyzed with MiniscopeAnalysis
++ Add - Load data acquired with Miniscope-DAQ-V3
++ Add - Load data analyzed with MiniscopeAnalysis
 
 [0.2.0]: https://github.com/datajoint/element-miniscope/releases/tag/0.2.0
 [0.1.4]: https://github.com/datajoint/element-miniscope/releases/tag/0.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Quality Control plotting tool and report schema
 + Fix - `.ipynb` output in tutorials is not visible in dark mode.
 
-
 ## [0.1.4] - 2022-10-21
 
 + Add - mkdocs deployment with workflow API docs

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -91,3 +91,7 @@ html a[title="YouTube"].md-social__link svg {
     /* previous/next text */
     /* --md-footer-fg-color: var(--dj-white); */
 }
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
+}


### PR DESCRIPTION
This PR fixes the output of tutorial notebooks when viewed in dark mode within the documentation.

The following tasks are a part of this PR:

- [x] Add docs fix to extra.css.
- [x] Update CHANGELOG.
- [x] Update version.py.
- [ ] Push an updated tag after the PR is merged.