### PR TITLE
Remove `Mask` quality metrics table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.3.0] - 2023-05-15
+## [0.3.0] - 2023-05-17
 
 + Add - Quality metrics
 + Update - README and docs to reflect new structure across all Elements

--- a/element_miniscope/miniscope.py
+++ b/element_miniscope/miniscope.py
@@ -1181,24 +1181,6 @@ class ProcessingQualityMetrics(dj.Computed):
     -> Fluorescence
     """
 
-    class Mask(dj.Part):
-        """Quality metrics used to evaluate the masks.
-
-        Attributes:
-            Fluorescence (foreign key): Primary key from Fluorescence.
-            Segmentation.Mask (foreign key): Primary key from Segmentation.Mask.
-            mask_area (float): Mask area in square micrometer.
-            roundness (float): Roundness between 0 and 1. Values closer to 1 are rounder.
-        """
-
-        definition = """
-        -> master
-        -> Segmentation.Mask
-        ---
-        mask_area=null: float  # Mask area in square micrometer.
-        roundness: float       # Roundness between 0 and 1. Values closer to 1 are rounder.
-        """
-
     class Trace(dj.Part):
         """Quality metrics used to evaluate the fluorescence traces.
 
@@ -1221,61 +1203,24 @@ class ProcessingQualityMetrics(dj.Computed):
         """Populate the ProcessingQualityMetrics table and its part tables."""
         from scipy.stats import skew
 
-        (
-            mask_xpixs,
-            mask_ypixs,
-            mask_weights,
-            fluorescence,
-            fluo_channels,
-            mask_ids,
-            mask_npix,
-            px_height,
-            px_width,
-            um_height,
-            um_width,
-        ) = (Segmentation.Mask * RecordingInfo * Fluorescence.Trace & key).fetch(
-            "mask_xpix",
-            "mask_ypix",
-            "mask_weights",
-            "fluorescence",
-            "fluo_channel",
-            "mask",
-            "mask_npix",
-            "px_height",
-            "px_width",
-            "um_height",
-            "um_width",
-        )
-
-        norm_mean = lambda x: x.mean() / x.max()
-        roundnesses = [
-            norm_mean(np.linalg.eigvals(np.cov(x, y, aweights=w)))
-            for x, y, w in zip(mask_xpixs, mask_ypixs, mask_weights)
-        ]
+        (fluorescence, fluorescence_channels, mask_ids,) = (
+            Segmentation.Mask * RecordingInfo * Fluorescence.Trace & key
+        ).fetch("fluorescence", "fluorescence_channel", "mask")
 
         fluorescence = np.stack(fluorescence)
 
         self.insert1(key)
 
-        self.Mask.insert(
-            dict(key, mask=mask_id, mask_area=mask_area, roundness=roundness)
-            for mask_id, mask_area, roundness in zip(
-                mask_ids,
-                mask_npix * (um_height / px_height) * (um_width / px_width),
-                roundnesses,
-            )
-        )
-
         self.Trace.insert(
             dict(
                 key,
-                fluo_channel=fluo_channel,
+                fluorescence_channel=fluorescence_channel,
                 mask=mask_id,
                 skewness=skewness,
                 variance=variance,
             )
-            for fluo_channel, mask_id, skewness, variance in zip(
-                fluo_channels,
+            for fluorescence_channel, mask_id, skewness, variance in zip(
+                fluorescence_channels,
                 mask_ids,
                 skew(fluorescence, axis=1),
                 fluorescence.std(axis=1),


### PR DESCRIPTION
- Removing this table due to an opaque error in the roundness calculation.  Will hopefully add this table back in the future.