### PR TITLE
Add opencv-python to requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.2] - 2023-07-20
+
++ Add `opencv-python` to requirements
+
 ## [0.3.1] - 2023-05-22
 
 + Add - CaImAn citation
@@ -46,6 +50,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Load data acquired with Miniscope-DAQ-V3
 + Add - Load data analyzed with MiniscopeAnalysis
 
+[0.3.2]: https://github.com/datajoint/element-miniscope/releases/tag/0.3.2
 [0.3.1]: https://github.com/datajoint/element-miniscope/releases/tag/0.3.1
 [0.3.0]: https://github.com/datajoint/element-miniscope/releases/tag/0.3.0
 [0.2.1]: https://github.com/datajoint/element-miniscope/releases/tag/0.2.1

--- a/element_miniscope/version.py
+++ b/element_miniscope/version.py
@@ -1,2 +1,2 @@
 """Package metadata"""
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 datajoint>=0.13.0
 element-interface>=0.3.0
+opencv-python


### PR DESCRIPTION
The missing requirement is needed to import `cv2` [here](https://github.com/datajoint/element-miniscope/blob/main/element_miniscope/miniscope.py#L9). 