### PR TITLE
Fix declaration of `get_miniscope_root_data_dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.4.1] - 2023-10-31
+
++ Fix - `tutorial_pipeline.py` markdown and variable name typos
+
 ## [0.4.0] - 2023-10-31
 
 + Add - DevContainer for codespaces

--- a/element_miniscope/version.py
+++ b/element_miniscope/version.py
@@ -1,2 +1,2 @@
 """Package metadata"""
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/notebooks/tutorial_pipeline.py
+++ b/notebooks/tutorial_pipeline.py
@@ -31,16 +31,18 @@ db_prefix = dj.config["custom"].get("database.prefix", "")
 
 # Declare functions for retrieving data
 def get_miniscope_root_data_dir():
-    """Retrieve imaging root data directory."""
-    imaging_root_dirs = dj.config.get("custom", {}).get("miniscope_root_data_dir", None)
-    if not imaging_root_dirs:
+    """Retrieve miniscope root data directory."""
+    miniscope_root_dirs = dj.config.get("custom", {}).get(
+        "miniscope_root_data_dir", None
+    )
+    if not miniscope_root_dirs:
         return None
-    elif isinstance(imaging_root_dirs, (str, pathlib.Path)):
-        return [imaging_root_dirs]
-    elif isinstance(imaging_root_dirs, list):
-        return imaging_root_dirs
+    elif isinstance(miniscope_root_dirs, (str, pathlib.Path)):
+        return [miniscope_root_dirs]
+    elif isinstance(miniscope_root_dirs, list):
+        return miniscope_root_dirs
     else:
-        raise TypeError("`imaging_root_data_dir` must be a string, pathlib, or list")
+        raise TypeError("`miniscope_root_data_dir` must be a string, pathlib, or list")
 
 
 # Activate schemas


### PR DESCRIPTION
This PR initially aimed to correct minor typos, changing `imaging_root_data_dir` to `miniscope_root_data_dir` in `tutorial_pipeline.py`. 

Following the review, a discussion has sparked on our approach to version and CHANGELOG updates across open-source repositories. The version and CHANGELOG in this PR have been manually updated for the time being, pending forthcoming documentation that will guide future version and changelog updates in subsequent PRs.