### PR TITLE
Update package requirements + format with `black`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,14 +4,6 @@ on:
 jobs:
   make_github_release:
     uses: datajoint/.github/.github/workflows/make_github_release.yaml@main
-  pypi_release:
-    needs: make_github_release
-    uses: datajoint/.github/.github/workflows/pypi_release.yaml@main
-    secrets:
-      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-    with:
-      UPLOAD_URL: ${{needs.make_github_release.outputs.release_upload_url}}
   mkdocs_release:
     uses: datajoint/.github/.github/workflows/mkdocs_release.yaml@main
     permissions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.4.1] - 2023-10-31
+## [0.4.2] - 2024-01-29
+
++ Fix - `element-interface` required during package installation
++ Fix - apply `black` formatting across the repository
++ Update - GitHub Actions no longer release to PyPI
+
+## [0.4.1] - 2024-01-22
 
 + Fix - `tutorial_pipeline.py` markdown and variable name typos
 
-## [0.4.0] - 2023-10-31
+## [0.4.0] - 2024-01-09
 
 + Add - DevContainer for codespaces
 + Add - `tutorial_pipeline.py`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 DataJoint
+Copyright (c) 2024 DataJoint
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/element_miniscope/version.py
+++ b/element_miniscope/version.py
@@ -1,2 +1,3 @@
 """Package metadata"""
-__version__ = "0.4.1"
+
+__version__ = "0.4.2"

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "ipywidgets",
         "plotly",
         "opencv-python",
+        "element-interface @ git+https://github.com/datajoint/element-interface.git",
     ],
     extras_require={
         "caiman_requirements": [caiman_requirements],
@@ -46,7 +47,6 @@ setup(
         "elements": [
             "element-animal @ git+https://github.com/datajoint/element-animal.git",
             "element-event @ git+https://github.com/datajoint/element-event.git",
-            "element-interface @ git+https://github.com/datajoint/element-interface.git",
             "element-lab @ git+https://github.com/datajoint/element-lab.git",
             "element-session @ git+https://github.com/datajoint/element-session.git",
         ],


### PR DESCRIPTION
This PR:

- [x] Removes PyPI release from GHA
- [x] Applies `black` formatting throughout the repo to pass pre-release checks
- [x] Updates `element-interface` as a requirement for the base installation of the package
- [ ] Once merged, tags for any missing versions from the CHANGELOG will be released